### PR TITLE
modifs pour préparer l'utilisation

### DIFF
--- a/admin/gestion.php
+++ b/admin/gestion.php
@@ -1,9 +1,9 @@
 
 <?php require "header.php"; 
-ouvre_bdd();
-if (isset($_POST['annonce'])) {
+ouvre_bdd(); 
+if (isset($_POST['annonce'])) { 
     maj_annonce();
-} elseif (isset($_POST['nom']) && isset($_POST['but'])) {
+} elseif (isset($_POST['nom']) && isset($_POST['but'])) { 
     if ($_POST['but']=="ajout") {
         ajout_staff();
     } elseif ($_POST['but']=="modif") {
@@ -12,7 +12,7 @@ if (isset($_POST['annonce'])) {
         $les_creneaux=lire_les_creneaux();
         supprime_staff();
     }
-}
+} 
 $annonce=lire_annonce() ;
 $le_staff=lecture_staff();
 ferme_bdd();
@@ -35,7 +35,7 @@ ferme_bdd();
                 <legend>Ajout d'une personne au staff :</legend><BR>
          <div class="perso"> <!-- grid layout on fieldset is buggy on Chrome -->
             <label for="nom">Nom</label>
-            <input id="nom" name="nom" />
+            <input id="nom" name="nom"/>
             <label for="mail">Mail</label>
             <input type="email" id="mail" name="mail" />
             <label for="telephone">Téléphone</label>

--- a/admin/gestion_java.js
+++ b/admin/gestion_java.js
@@ -9,6 +9,7 @@ let inputid=document.getElementById("inputid")
 let but=document.getElementById("but")
 
 function ajusteDonneesStaff() {
+    if (leStaff[amodifier.value]==null) { return }
     nommodif.value=leStaff[amodifier.value]['nom']
     mailmodif.value=leStaff[amodifier.value]['mail']
     telephonemodif.value=leStaff[amodifier.value]['telephone']

--- a/staff/staff_java.js
+++ b/staff/staff_java.js
@@ -15,15 +15,16 @@ function click_creneau(id,action='avecclick') {
 	}).then(function(res){ return res.json();})
 	  .then(function(res){
 		statut=res[0]
-		nb=res[1]
+		nb=parseInt(res[1],10)
+		if (isNaN(nb) || nb<-1 || nb>10000) { return }
 		if (statut=="oui") { 
 			label.style.backgroundColor="#FAB315"
 			label.style.color="black"
 			label.innerHTML="Présent(e)";
-			if (nb=="0") {
+			if (nb==0) {
 			   nombre.innerHTML=nb+" personne(s)"
 			   titre.className="creneauvide"
-			} else if (nb!="-1") {
+			} else if (nb!=-1) {
 			   nombre.innerHTML=nb+" personne(s)"
 			   titre.className=""
 			}   
@@ -31,16 +32,16 @@ function click_creneau(id,action='avecclick') {
 			label.style.backgroundColor="#2687c9"
 			label.style.color="white"
 			label.innerHTML="Absent(e)";
-			if (nb=="0") {
+			if (nb==0) {
 			   nombre.innerHTML=nb+" personne(s)"
 			   titre.className="creneauvide"
-			} else if (nb!="-1") {
+			} else if (nb!=-1) {
 			   nombre.innerHTML=nb+" personne(s)"
 			   titre.className=""
 			}   
 		} else if (statut=="sibesoin") { 
 			if (action=='avecclick') {
-			if (nb=="0") {
+			if (nb==0) {
 				alert('Tu es le seul staffeur sur ce créneau. Es-tu sûr de vouloir te désinscrire du créneau ? N’oublie pas de prévenir de ton absence sur le groupe What’s App du staff pour trouver un-e remplaçant-e.')
 				mail_creneau_vide(titre.innerHTML)
 			} else {
@@ -71,5 +72,5 @@ function mail_creneau_vide(titre) {
   	  },
   	  body: formData
 	}).then(function(res){ return res.json();})
-	  .then(function(res){ console.log(res);})	  
+	  .then(function(res){ })	  
 }


### PR DESCRIPTION
Envoie de mail pour la création de staff au lieu d'afficher un message
correction d'un bug s'il n'y a pas de staff dans le menu de gestion
sécurisation de la création de login : seuls les lettre/chifres/espaces sont acceptés maintenant
sécurisation de la réception du json lors des requêtes partielles
correction de la suppression d'un staffeur en tenant compte du "sibesoin" lors de la maj du nombre de personnes restantes